### PR TITLE
Implement specific phrasing for event times

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -16,7 +16,7 @@
         <br/>
         <span class="event"></span>
         <br/>
-        <span class="event-date"></span> @ <span class="event-time"></span>
+        <span class="event-time"></span>
     </h2>
     <h1 class="time"></h1>
 </body>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -4,17 +4,59 @@ function getJSON(url) {
 }
 
 const $event = document.querySelector(".event"),
-      $eventDate = document.querySelector(".event-date"),
       $eventTime = document.querySelector(".event-time");
 
 function setEventDetails(eventObject) {
     localStorage.nextEvent = JSON.stringify(eventObject);
     $event.textContent = eventObject.summary;
-    const eventDateTime = (new Date(eventObject.start)),
-          eventDate = eventDateTime.toLocaleDateString().slice(0, -5),
-          eventTime = eventDateTime.toLocaleTimeString().split(":").slice(0, -1).join(":");
-    $eventDate.textContent = eventDate;
-    $eventTime.textContent = eventTime;
+    console.log(JSON.stringify(eventObject));
+    const daysPerMillisecond = 1 / (1000 * 60 * 60 * 24),
+          nowDateTime = Date.now(),
+          startDateTime = new Date(eventObject.start),
+          relativeMillis = startDateTime - nowDateTime,
+          relativeDays = parseInt(startDateTime * daysPerMillisecond, 10)
+            - parseInt(nowDateTime * daysPerMillisecond, 10),
+          startDate = startDateTime.toLocaleDateString().slice(0, -5),
+          startTime = startDateTime.toLocaleTimeString().split(":").slice(0, -1).join(":");
+
+    let eventTimeString = startDate + " at " + startTime;
+    const days = [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ];
+    if (relativeDays < 7) {
+        if (relativeDays > 1) {
+            // The event is happening within a week
+            eventTimeString = "on " + days[startDateTime.getDay()] + " at " + startTime;
+        } else if (relativeDays === 1) {
+            // The event is happening tomorrow
+            eventTimeString = "tomorrow at " + startTime;
+        } else if (relativeDays <= 0) {
+            if (relativeMillis > 1000 * 60 * 60 * 4) {
+                // Event is happening today (in more than 4 hours)
+                eventTimeString = "today at " + startTime;
+            } else if (relativeMillis >= 1000 * 60 * 60) {
+                // Event is happening within 4 hours, but in more than 1 hour
+                const hours = parseInt(relativeMillis / (1000 * 60 * 60), 10);
+                eventTimeString = "in " + hours + " hour" + (hours > 1 ? "s" : "");
+                setTimeout(() => {
+                    // Update the display of the event details (without re-requesting the event)
+                    setEventDetails(eventObject);
+                }, (hours > 1 ? 1000 * 60 * 60 : relativeMillis - (1000 * 60 * 60)));
+            } else {
+                const minutes = parseInt(relativeMillis / (1000 * 60), 10);
+                if (minutes > 0) {
+                    eventTimeString = "in " + minutes + " minute" + (minutes > 1 ? "s" : "");
+                    setTimeout(() => {
+                        // Update the display of the event details (without re-requesting the event)
+                        setEventDetails(eventObject);
+                    }, 1000 * 60);
+                } else if (new Date(eventObject.end) - nowDateTime < 0) {
+                    eventTimeString = "this event has finished";
+                } else {
+                    eventTimeString = "it's happening now!";
+                }
+            }
+        }
+    }
+    $eventTime.textContent = eventTimeString;
 }
 
 async function updateEvent() {


### PR DESCRIPTION
Gradually adjusts the event time to specify which day of the week it's happening on (if within 7 days), then says 'tomorrow', then 'today', then 'in x hours', then 'in y minutes', then 'happening now'. Also implements the 'already happened' catch case on the off chance that the next event isn't correctly loaded from the LCPT API.